### PR TITLE
Add route tables for Mongo Atlas VPC peering

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,23 +2,32 @@
 
 USAGE="
 Usage:
-  PLAN:  ./deploy.sh plan <fp_context> <domain>
-  APPLY: ./deploy.sh apply <fp_context> <domain>
+  PLAN:  ./deploy.sh plan <fp_context>
+  APPLY: ./deploy.sh apply <fp_context>
 "
 
-if [[ -z "$1" || -z "$2" || -z "$3" ]]; then
+if [[ -z "$1" || -z "$2" ]]; then
   echo "$USAGE"
   exit 1
 fi
 
 action=$1
 fp_context=$2
-domain=$3
+
+if [[ "$action" != "plan" && "$action" != "apply" ]]; then
+  echo "$USAGE"
+  exit 1
+fi
+
+if [[ ! -f $fp_context.env ]]; then
+  echo "Cannot find $fp_context.env file."
+  exit 1
+fi
 
 . $fp_context.env
 
 export TF_VAR_fp_context=$fp_context
-export TF_VAR_domain=$domain
+export TF_VAR_domain=$DOMAIN
 export TF_VAR_mongo_project_id=$MONGODB_ATLAS_PROJECT_ID
 export TF_VAR_aws_account_id=$AWS_ACCOUNT_ID
 export TF_VAR_mongo_host=$MONGODB_HOST

--- a/mongo.tf
+++ b/mongo.tf
@@ -31,24 +31,11 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   auto_accept = true
 }
 
-# Route tables for peering connection
-# TODO figure out how to make this DRY using a loop
-resource "aws_route" "peering-owner-az1" {
-  route_table_id            = module.vpc.private_route_table_ids[0]
-  destination_cidr_block    = "10.8.0.0/21"
+resource "aws_route" "peering_to_owner" {
+  for_each = toset(module.vpc.private_route_table_ids)
+  destination_cidr_block = "10.8.0.0/21"
   vpc_peering_connection_id = mongodbatlas_network_peering.peer.connection_id
-}
-
-resource "aws_route" "peering-owner-az2" {
-  route_table_id            = module.vpc.private_route_table_ids[1]
-  destination_cidr_block    = "10.8.0.0/21"
-  vpc_peering_connection_id = mongodbatlas_network_peering.peer.connection_id
-}
-
-resource "aws_route" "peering-owner-az3" {
-  route_table_id            = module.vpc.private_route_table_ids[2]
-  destination_cidr_block    = "10.8.0.0/21"
-  vpc_peering_connection_id = mongodbatlas_network_peering.peer.connection_id
+  route_table_id = each.value
 }
 
 resource "mongodbatlas_project_ip_whitelist" "whitelist" {

--- a/mongo.tf
+++ b/mongo.tf
@@ -31,6 +31,26 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   auto_accept = true
 }
 
+# Route tables for peering connection
+# TODO figure out how to make this DRY using a loop
+resource "aws_route" "peering-owner-az1" {
+  route_table_id            = module.vpc.private_route_table_ids[0]
+  destination_cidr_block    = "10.8.0.0/21"
+  vpc_peering_connection_id = mongodbatlas_network_peering.peer.connection_id
+}
+
+resource "aws_route" "peering-owner-az2" {
+  route_table_id            = module.vpc.private_route_table_ids[1]
+  destination_cidr_block    = "10.8.0.0/21"
+  vpc_peering_connection_id = mongodbatlas_network_peering.peer.connection_id
+}
+
+resource "aws_route" "peering-owner-az3" {
+  route_table_id            = module.vpc.private_route_table_ids[2]
+  destination_cidr_block    = "10.8.0.0/21"
+  vpc_peering_connection_id = mongodbatlas_network_peering.peer.connection_id
+}
+
 resource "mongodbatlas_project_ip_whitelist" "whitelist" {
   project_id = local.project_id
   cidr_block = module.vpc.vpc_cidr_block

--- a/parameters.tf
+++ b/parameters.tf
@@ -7,7 +7,7 @@ resource "aws_ssm_parameter" "db_host" {
 resource "aws_ssm_parameter" "db_user" {
   name = "/fp/database/user"
   type = "String"
-  value = "fp_app"
+  value = mongodbatlas_database_user.fp_app.username
 }
 
 resource "aws_ssm_parameter" "db_password" {


### PR DESCRIPTION
This is required for any service on a private subnet in our VPC to be able to connect to the MongoDB Atlas cluster over the VPC peering connection